### PR TITLE
fix: isSignup 파라미터 기반으로 oauth callback 리다이렉트 로직 수정

### DIFF
--- a/src/app/oauth/callback/route.ts
+++ b/src/app/oauth/callback/route.ts
@@ -13,7 +13,7 @@ export async function GET(request: NextRequest) {
     request.headers.get('host') ||
     'localhost:3000';
   const code = searchParams.get('code');
-  const isSignup = searchParams.get('isSignup');
+  const isSignup = searchParams.get('isSignup') === 'true';
   const redirectParam = searchParams.get('redirect');
   let redirect: string | null = null;
 
@@ -73,17 +73,6 @@ export async function GET(request: NextRequest) {
       `${redirectPath}${buildQuery(urlQuery)}`,
       `${protocol}://${host}`,
     );
-
-    // if (isSignup) {
-    //   redirectUrl.searchParams.set(
-    //     'onboarding',
-    //     data.result.isOnboarded.toString(),
-    //   );
-    //   redirectUrl.searchParams.set(
-    //     'name',
-    //     encodeURIComponent(data.result.name),
-    //   );
-    // }
 
     // redirect 응답 객체 생성
     const res = NextResponse.redirect(redirect || redirectUrl);

--- a/src/app/oauth/callback/route.ts
+++ b/src/app/oauth/callback/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: NextRequest) {
     request.headers.get('host') ||
     'localhost:3000';
   const code = searchParams.get('code');
+  const isSignup = searchParams.get('isSignup');
   const redirectParam = searchParams.get('redirect');
   let redirect: string | null = null;
 
@@ -59,30 +60,30 @@ export async function GET(request: NextRequest) {
 
     let redirectPath = '/main';
     const urlQuery: Record<string, string> = {};
-    if (data.result.isOnboarded) {
+    if (isSignup) {
+      urlQuery.authType = 'signup';
+      redirectPath = '/onboarding';
+    } else {
       urlQuery.authType = 'login';
       if (entry === 'create-album') {
         redirectPath = '/create-album';
       }
-    } else {
-      urlQuery.authType = 'signup';
-      redirectPath = '/onboarding';
     }
     const redirectUrl = new URL(
       `${redirectPath}${buildQuery(urlQuery)}`,
       `${protocol}://${host}`,
     );
 
-    if (!data.result.isOnboarded) {
-      redirectUrl.searchParams.set(
-        'onboarding',
-        data.result.isOnboarded.toString(),
-      );
-      redirectUrl.searchParams.set(
-        'name',
-        encodeURIComponent(data.result.name),
-      );
-    }
+    // if (isSignup) {
+    //   redirectUrl.searchParams.set(
+    //     'onboarding',
+    //     data.result.isOnboarded.toString(),
+    //   );
+    //   redirectUrl.searchParams.set(
+    //     'name',
+    //     encodeURIComponent(data.result.name),
+    //   );
+    // }
 
     // redirect 응답 객체 생성
     const res = NextResponse.redirect(redirect || redirectUrl);


### PR DESCRIPTION
## Summary
- `isOnboarded` 서버 응답값 기반 리다이렉트 로직을 `isSignup` 쿼리 파라미터 기반으로 변경
- 신규 가입 시 `/onboarding`, 기존 로그인 시 기존 흐름(`login`, `create-album` 등)으로 분기
